### PR TITLE
escape the example Lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ of a distribution. May also be a binary repository by a third party.
 
 #### Example property
 
-* http://ftp.us.debian.org/debian/
-* https://downloads.openwrt.org/
-* https://download.docker.com/
+* `http://ftp.us.debian.org/debian/`
+* `https://downloads.openwrt.org/`
+* `https://download.docker.com/`
 
 ### `origin_name` (string)
 
@@ -67,9 +67,9 @@ distribution identifier in the database.
 
 #### Example property
 
-* debian
-* openwrt
-* docker
+* `debian`
+* `openwrt`
+* `docker`
 
 ### `results` (list)
 
@@ -82,9 +82,9 @@ available branches in which a binary is distributed by the same distribution.
 
 #### Example property
 
-* buster
-* 19.07
-* rolling
+* `buster`
+* `19.07`
+* `rolling`
 
 ### `component` (string)
 
@@ -93,10 +93,10 @@ available per suite.
 
 #### Example property
 
-* main
-* core
-* community
-* iso
+* `main`
+* `core`
+* `community`
+* `iso`
 
 ### `target` (enum)
 
@@ -112,9 +112,9 @@ A complete list TBA.
 
 #### Example property
 
-* x86_64-unknown-linux-gnu
-* mipsel-unknown-linux-musl
-* aarch64-linux-android
+* `x86_64-unknown-linux-gnu`
+* `mipsel-unknown-linux-musl`
+* `aarch64-linux-android`
 
 ### `name` (string)
 
@@ -124,9 +124,9 @@ should not contain any version information.
 
 #### Example property
 
-* tmux
-* procd
-* firefox
+* `tmux`
+* `procd`
+* `firefox`
 
 ### `cpe` (string) [optional]
 
@@ -139,8 +139,8 @@ Offering this information allows interpretability between distributions.
 
 #### Example property
 
-* cpe:2.3:a:mozilla:firefox:*:*:*:*:*:*:*:*
-* cpe:2.3:a:haxx:curl:*:*:*:*:*:*:*:*
+* `cpe:2.3:a:mozilla:firefox:*:*:*:*:*:*:*:*`
+* `cpe:2.3:a:haxx:curl:*:*:*:*:*:*:*:*`
 
 ### `status` (enum)
 
@@ -149,15 +149,15 @@ of statues to chose from.
 
 All states are explained blow:
 
-* reproducible: recreated binary has the same checksum
-* unreproducible: binary compiles but results in a different checksum
-* buildfail: the creation was not successful and the build system failed
-* notfound: the sources required for the package are not available (anymore)
-* timeout: the build exceeded a specified time limit
-* blocked: the binary where actively excluded from testing
-* notforus: the binary is not compatible with the active target
-* untested: the binary has not yet been tested
-* depwait: the binary depends on an to be created other binary
+* `reproducible`: recreated binary has the same checksum
+* `unreproducible`: binary compiles but results in a different checksum
+* `buildfail`: the creation was not successful and the build system failed
+* `notfound`: the sources required for the package are not available (anymore)
+* `timeout`: the build exceeded a specified time limit
+* `blocked`: the binary where actively excluded from testing
+* `notforus`: the binary is not compatible with the active target
+* `untested`: the binary has not yet been tested
+* `depwait`: the binary depends on an to be created other binary
 
 ### `artifacts` (dictionary)
 


### PR DESCRIPTION
some would be rendered as weird unicode, and in general it makes clear
that we are referring to them as plain strings.